### PR TITLE
Don't double-write to headers during authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.edwardthomson</groupId>
     <artifactId>poxygit</artifactId>
-    <version>0.8.0</version>
+    <version>0.8.1</version>
     <name>com.edwardthomson.poxygit</name>
 
     <properties>

--- a/src/main/java/com/edwardthomson/poxygit/Connection.java
+++ b/src/main/java/com/edwardthomson/poxygit/Connection.java
@@ -20,6 +20,7 @@ import java.net.URI;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -418,7 +419,7 @@ public class Connection implements Runnable
 	private boolean authenticate(RequestInfo requestInfo, Request request, Response response) throws Exception
 	{
 		final Header authentication = findHeader(Constants.AUTHORIZATION_HEADER, request.getHeaders());
-		final List<Header> responseHeaders = response.getHeaders();
+		final List<Header> responseHeaders = new ArrayList<Header>();
 		String challengeMessage = null;
 
 		if (authentication != null)


### PR DESCRIPTION
We updated the response to store the headers that were being sent (to understand when `Connection: close` was sent). But we were also _taking_ the headers in authentication. This led to us writing them twice during authentication.